### PR TITLE
fix tomsk rts account

### DIFF
--- a/inter_rao_energosbyt/api/tomsk.py
+++ b/inter_rao_energosbyt/api/tomsk.py
@@ -62,6 +62,9 @@ class TMKNRGMeter(AbstractBytSubmittableMeter):
 @TomskEnergosbytAPI.register_supported_account(
     provider_type=ProviderType.TMK_NRG,
 )
+@TomskEnergosbytAPI.register_supported_account(
+    provider_type=ProviderType.TMK_RTS
+)
 class TMKNRGAccount(
     AccountWithViewInvoices,
     AccountWithViewPayments,


### PR DESCRIPTION
У меня интеграция не работает. Я выяснил что проблем в том что у моего аккаунта другой provider_type. Так что я добавил provider_type=4 для томского аккаунта. @alryaz можешь обновить либу и интеграцию пожалуйста с этой правкой)